### PR TITLE
Bump version to v0.0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jito-bell"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Jito Network Maintainers <support@jito.network>"]
 repository = "https://github.com/jito-foundation/jito-bell"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -112,6 +112,6 @@ docker run jito-bell \
 ## References
 - https://github.com/rpcpool/yellowstone-grpc/blob/master/examples/rust/src/bin/tx-blocktime.rs
 
-## LICENCE
+## License
 
 This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE.txt) file for details.

--- a/README.md
+++ b/README.md
@@ -111,3 +111,7 @@ docker run jito-bell \
 
 ## References
 - https://github.com/rpcpool/yellowstone-grpc/blob/master/examples/rust/src/bin/tx-blocktime.rs
+
+## LICENCE
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE.txt) file for details.


### PR DESCRIPTION
- Track CPI
- Add new configuration field `explorer_url` like `explorer_url: "https://solscan.io"`
- Set `failed` argument to `true`