### PR TITLE
Avoid using hardcoding divisor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2191,6 +2191,7 @@ dependencies = [
  "solana-rpc-client-api",
  "solana-sdk",
  "spl-stake-pool",
+ "spl-token",
  "spl-token-2022 0.9.0",
  "thiserror 2.0.12",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ solana-rpc-client = "1.17.6"
 solana-rpc-client-api = "1.17.6"
 solana-sdk = "1.17.6"
 spl-stake-pool = { version = "^1.0.0", features = ["no-entrypoint"] }
+spl-token = { version = "4.0.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.9", features = [ "no-entrypoint", "serde-traits" ] }
 thiserror = "2.0.12"
 tokio = { version = "1.0.1", features = ["full"] }


### PR DESCRIPTION
Vault: 4xob1G527bKP8xfSmPCH8aqATWJ93vd8iyfvYKDqDPBt
VRT: DVhYSox7hQVoaUKcy1SUGmtPWamXVb1HcGLuF4fyvaAr

### Mint VRT

```bash
 cargo r -p jito-restaking-cli -- vault vault mint-vrt 4xob1G527bKP8xfSmPCH8aqATWJ93vd8iyfvYKDqDPBt 200000000 100000000
```

### Enqueue withdrawal

```bash
> cargo r -p jito-restaking-cli -- vault vault enqueue-withdrawal 4xob1G527bKP8xfSmPCH8aqATWJ93vd8iyfvYKDqDPBt 50000000
```